### PR TITLE
Fixes for v2018.09.04

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ycmd"]
+	path = ycmd
+	url = https://github.com/Valloric/ycmd

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -7,24 +7,21 @@ Install
 -------
 
 
-```console
+```bash
 # Clone kak-ycmd in $HOME/.local/share
 git clone https://github.com/negativedensity/kak-ycmd.git $HOME/.local/share```
 
 # Init submodules, may take some time since ycmd is bundled.
-
 cd $HOME/.local/share/kak-ycmd
 git submodule update --init --recursive
 
 # Go to ycmd subdirectory and build ycmd.
 # See https://github.com/Valloric/ycmd#building for instructions and required dependencies.
 # Below is the command for building only the Clang completer.
-
 cd ycmd
 python3 build.py --clang-completer
 
 # Finally, link ycmd.kak in autoload.
-
 ln -sv $HOME/.local/share/kak-ycmd/ycmd.kak $HOME/.config/kak/autoload/ycmd.kak
 ```
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -3,22 +3,31 @@ Kakoune YouCompleteMe Script
 
 This script provides YouCompleteMe support via ycmd in Kakoune.
 
-It works for C/C++ with the clang completer, other languages
-are not tested yet.
+Install
+-------
+
+Clone `kak-ycmd` in `$HOME/.local/share`
+
+> git clone https://github.com/negativedensity/kak-ycmd.git $HOME/.local/share
+
+Init submodules, may take some time since ycmd is bundled.
+
+> cd `$HOME/.local/share/kak-ycmd`
+> git submodule update --init --recursive
+
+Go to `ycmd` subdirectory and build ycmd.
+See https://github.com/Valloric/ycmd#building for instructions and required dependencies.
+Below is the command for building only the Clang completer.
+
+> cd ycmd
+> python3 build.py --clang-completer
+
+Finally, link `ycmd.kak` in `autoload`.
+
+> ln -sv `$HOME/.local/share/kak-ycmd/ycmd.kak` `$HOME/.config/kak/autoload/ycmd.kak`
 
 Usage
 -----
-
-To use that script, link to it in ~/.config/kak/autoload, and
-set options in your kakrc:
-
-* +ycmd_path+: path of the ycmd python directory, on a cloned
-               ycmd repo, that would be $REPO/ycmd
-
-* +ycmd_port+: (defaulting to 12345) port to use for ycmd.
-
-The cpp part of ycmd must be compiled manually, with clang
-support.
 
 Ycmd completion can be enabled with ycmd-enable-autocomplete
 command.
@@ -29,6 +38,17 @@ To automate its activation, use a hook:
 hook global WinSetOption filetype=cpp %{ ycmd-enable-autocomplete }
 hook global WinSetOption filetype=(?!cpp).* %{ ycmd-disable-autocomplete }
 --------------------------------------------------------------------------
+
+Options
+-------
+
+* +kak_ycmd_path+: (defaulting to `$HOME/.local/share/kak-ycmd`) path of the kak-ycmd directory.
+
+* +ycmd_settings_template_path+: (defaulting to `<kak_ycmd_path>/default_settings.json.template`) template to as ycmd's settings file.
+The JSON needs to have a `"hmac_secret": "__HMAC_SECRET__"` entry.
+See the default file for details.
+
+* +ycmd_port+: (defaulting to 12345) port to use for ycmd.
 
 Dependencies
 ------------

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -9,7 +9,7 @@ Install
 
 ```bash
 # Clone kak-ycmd in $HOME/.local/share
-git clone https://github.com/negativedensity/kak-ycmd.git $HOME/.local/share```
+git clone https://github.com/negativedensity/kak-ycmd.git $HOME/.local/share
 
 # Init submodules, may take some time since ycmd is bundled.
 cd $HOME/.local/share/kak-ycmd

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -6,25 +6,27 @@ This script provides YouCompleteMe support via ycmd in Kakoune.
 Install
 -------
 
-Clone `kak-ycmd` in `$HOME/.local/share`
 
-> git clone https://github.com/negativedensity/kak-ycmd.git $HOME/.local/share
+```console
+# Clone kak-ycmd in $HOME/.local/share
+git clone https://github.com/negativedensity/kak-ycmd.git $HOME/.local/share```
 
-Init submodules, may take some time since ycmd is bundled.
+# Init submodules, may take some time since ycmd is bundled.
 
-> cd `$HOME/.local/share/kak-ycmd`
-> git submodule update --init --recursive
+cd $HOME/.local/share/kak-ycmd
+git submodule update --init --recursive
 
-Go to `ycmd` subdirectory and build ycmd.
-See https://github.com/Valloric/ycmd#building for instructions and required dependencies.
-Below is the command for building only the Clang completer.
+# Go to ycmd subdirectory and build ycmd.
+# See https://github.com/Valloric/ycmd#building for instructions and required dependencies.
+# Below is the command for building only the Clang completer.
 
-> cd ycmd
-> python3 build.py --clang-completer
+cd ycmd
+python3 build.py --clang-completer
 
-Finally, link `ycmd.kak` in `autoload`.
+# Finally, link ycmd.kak in autoload.
 
-> ln -sv `$HOME/.local/share/kak-ycmd/ycmd.kak` `$HOME/.config/kak/autoload/ycmd.kak`
+ln -sv $HOME/.local/share/kak-ycmd/ycmd.kak $HOME/.config/kak/autoload/ycmd.kak
+```
 
 Usage
 -----

--- a/default_settings.json.template
+++ b/default_settings.json.template
@@ -1,0 +1,54 @@
+{
+  "filepath_completion_use_working_dir": 0,
+  "auto_trigger": 1,
+  "min_num_of_chars_for_completion": 2,
+  "min_num_identifier_candidate_chars": 0,
+  "semantic_triggers": {},
+  "filetype_specific_completion_to_disable": {
+    "gitcommit": 1
+  },
+  "seed_identifiers_with_syntax": 0,
+  "collect_identifiers_from_comments_and_strings": 0,
+  "collect_identifiers_from_tags_files": 0,
+  "max_num_identifier_candidates": 10,
+  "max_num_candidates": 50,
+  "extra_conf_globlist": [],
+  "global_ycm_extra_conf": "",
+  "confirm_extra_conf": 1,
+  "complete_in_comments": 0,
+  "complete_in_strings": 1,
+  "max_diagnostics_to_display": 30,
+  "filetype_whitelist": {
+    "*": 1
+  },
+  "filetype_blacklist": {
+    "tagbar": 1,
+    "qf": 1,
+    "notes": 1,
+    "markdown": 1,
+    "netrw": 1,
+    "unite": 1,
+    "text": 1,
+    "vimwiki": 1,
+    "pandoc": 1,
+    "infolog": 1,
+    "mail": 1
+  },
+  "filepath_blacklist": {
+    "html": 1,
+    "jsx": 1,
+    "xml": 1
+  },
+  "auto_start_csharp_server": 1,
+  "auto_stop_csharp_server": 1,
+  "use_ultisnips_completer": 1,
+  "csharp_server_port": 0,
+  "hmac_secret": "__HMAC_SECRET__",
+  "server_keep_logfiles": 0,
+  "gocode_binary_path": "",
+  "godef_binary_path": "",
+  "rust_src_path": "",
+  "racerd_binary_path": "",
+  "python_binary_path": "",
+  "java_jdtls_use_clean_workspace": 1
+}

--- a/ycmd.kak
+++ b/ycmd.kak
@@ -59,7 +59,6 @@ def ycmd-complete %{
                 \"line_num\": $kak_cursor_line,
                 \"column_num\": $kak_cursor_column,
                 \"filepath\": \"$kak_buffile\",
-                \"force_semantic\": true,
                 \"file_data\": {
                     \"$kak_buffile\": {
                         \"filetypes\": [ \"$kak_opt_filetype\" ],

--- a/ycmd.kak
+++ b/ycmd.kak
@@ -21,7 +21,7 @@ def ycmd-start %{ evaluate-commands %sh{
           set global ycmd_hmac_key ${key}
           hook global KakEnd .* %{ ycmd-stop }
           eval -draft %{
-              edit! -fifo ${dir}/fifo *debug*
+              edit! -fifo ${dir}/fifo *ycmd-output*
               hook buffer BufCloseFifo .* %{ nop %sh{ rm -r ${dir} } }
           }"
 
@@ -97,7 +97,7 @@ X-Ycm-Hmac: $hmac"
 
 def ycmd-enable-autocomplete %{
     set buffer ycmd_completions %opt{ycmd_completions}
-    set -add buffer completers option=ycmd_completions
+    set buffer completers word=buffer filename option=ycmd_completions
     hook -group ycmd_autocomplete window InsertIdle .* %{ try %{
         echo 'completing...'
         ycmd-complete
@@ -106,6 +106,7 @@ def ycmd-enable-autocomplete %{
 
 def ycmd-disable-autocomplete %{
     rmhooks window ycmd_autocomplete
+    unset-option buffer completers
     unset-option buffer ycmd_completions
 }
 

--- a/ycmd.kak
+++ b/ycmd.kak
@@ -21,7 +21,7 @@ def ycmd-start %{ evaluate-commands %sh{
           set global ycmd_hmac_key ${key}
           hook global KakEnd .* %{ ycmd-stop }
           eval -draft %{
-              edit! -fifo ${dir}/fifo *ycmd-output*
+              edit! -fifo ${dir}/fifo *debug*
               hook buffer BufCloseFifo .* %{ nop %sh{ rm -r ${dir} } }
           }"
 
@@ -97,7 +97,7 @@ X-Ycm-Hmac: $hmac"
 
 def ycmd-enable-autocomplete %{
     set buffer ycmd_completions %opt{ycmd_completions}
-    set buffer completers option=ycmd_completions
+    set -add buffer completers option=ycmd_completions
     hook -group ycmd_autocomplete window InsertIdle .* %{ try %{
         echo 'completing...'
         ycmd-complete
@@ -107,7 +107,6 @@ def ycmd-enable-autocomplete %{
 def ycmd-disable-autocomplete %{
     rmhooks window ycmd_autocomplete
     unset-option buffer ycmd_completions
-    unset-option buffer completers
 }
 
 # For debugging: send a request with path $1 and print the response to the debug window

--- a/ycmd.kak
+++ b/ycmd.kak
@@ -7,6 +7,7 @@ decl -hidden str ycmd_hmac_key
 decl -hidden str ycmd_tmp_dir
 decl -hidden completions ycmd_completions
 
+
 def ycmd-start %{ evaluate-commands %sh{
     dir=$(mktemp -d -t kak-ycmd.XXXXXXXX)
     # Avoid null bytes in the key, as we need to pass it as an argument to openssl
@@ -33,6 +34,12 @@ def ycmd-start %{ evaluate-commands %sh{
 def ycmd-stop %{
     nop %sh{ if [ ${kak_opt_ycmd_pid} -gt 0 ]; then kill ${kak_opt_ycmd_pid}; fi }
     set global ycmd_pid 0
+}
+
+def mk %{
+    make
+    ycmd-stop
+    ycmd-start
 }
 
 def ycmd-complete %{
@@ -79,13 +86,11 @@ httphdr="Content-Type: application/json; charset=utf8
 X-Ycm-Hmac: $hmac"
 
             json=$(curl -H "$httphdr" "http://127.0.0.1:${port}${path}" -d "$query" 2> ${dir}/curl-err)
-            compl=$(printf '%s' "$json" | jq -j '.completions[] | "\(.insertion_text)|\(.menu_text)|\(.insertion_text)" | gsub(":"; "\\:") + ":"' 2> ${dir}/jq-err | head -c -1)
+            compl=$(printf '%s' "$json" | jq -j ".completions[] | \"'\"+.insertion_text+\"|\"+.extra_menu_info+\"|\"+.menu_text+\"' \"" 2> ${dir}/jq-err | head -c -1)
             column=$(printf '%s' "$json" | jq -j .completion_start_column 2>> ${dir}/jq-err)
-            header="${kak_cursor_line}.${column}@${kak_timestamp}"
-            compl="${header}:${compl}"
-            compl="${compl//(/[}"
-            compl="${compl//)/]}"
-            echo "eval -client ${kak_client} %(echo completed; set 'buffer=${kak_buffile}' ycmd_completions %(${compl}) )" | kak -p ${kak_session}
+            header="'${kak_cursor_line}.${column}@${kak_timestamp}'"
+            compl="${header} ${compl}"
+            printf '%s' "eval -client ${kak_client} %{echo completed; set 'buffer=${kak_buffile}' ycmd_completions ${compl}}" | kak -p ${kak_session}
         ) > /dev/null 2>&1 < /dev/null &
     }
 }
@@ -102,4 +107,54 @@ def ycmd-enable-autocomplete %{
 def ycmd-disable-autocomplete %{
     rmhooks window ycmd_autocomplete
     unset-option buffer ycmd_completions
+}
+
+# For debugging: send a request with path $1 and print the response to the debug window
+def -params 1 ycmd-request %{
+    evaluate-commands %sh{
+        if [ ${kak_opt_ycmd_pid} -eq 0 ]; then
+            echo "echo 'auto starting ycmd server'
+                  ycmd-start"
+        fi
+    }
+    evaluate-commands %sh{ echo "write ${kak_opt_ycmd_tmp_dir}/buf.cpp" }
+    # end the previous %sh{} so that its output gets interpreted by kakoune
+    # before launching the following as a background task.
+    evaluate-commands %sh{
+        dir=${kak_opt_ycmd_tmp_dir}
+        # this runs in a detached shell, asynchronously, so that kakoune does not hang while ycmd is running.
+        # As completions references a cursor position and a buffer timestamp, only valid completions should be
+        # displayed.
+        (
+            key=$(printf '%s' "${kak_opt_ycmd_hmac_key}" | base64 -d -w0)
+
+            compute_hmac() { openssl dgst -sha256 -hmac "$key" -binary; }
+
+            query="{
+                \"line_num\": $kak_cursor_line,
+                \"column_num\": $kak_cursor_column,
+                \"filepath\": \"$kak_buffile\",
+                \"file_data\": {
+                    \"$kak_buffile\": {
+                        \"filetypes\": [ \"$kak_opt_filetype\" ],
+                        \"contents\": $(jq -Rs . $dir/buf.cpp)
+                    }
+                }
+            }"
+            port=${kak_opt_ycmd_port}
+            path="/${1}"
+            method="POST"
+
+            path_hmac=$(printf '%s' "$path" | compute_hmac | base64 -w0)
+            method_hmac=$(printf '%s' "$method" | compute_hmac | base64 -w0)
+            body_hmac=$(printf '%s' "$query" | compute_hmac | base64 -w0)
+            hmac=$(printf '%s' "${method_hmac}${path_hmac}${body_hmac}" | base64 -d -w0 | compute_hmac | base64 -w0)
+
+httphdr="Content-Type: application/json; charset=utf8
+X-Ycm-Hmac: $hmac"
+
+            json=$(curl -H "$httphdr" "http://127.0.0.1:${port}${path}" -d "$query" 2> ${dir}/curl-err)
+            printf '%s' "$json" | jq . > ${dir}/fifo
+        ) > /dev/null 2>&1 < /dev/null &
+    }
 }

--- a/ycmd.kak
+++ b/ycmd.kak
@@ -97,7 +97,7 @@ X-Ycm-Hmac: $hmac"
 
 def ycmd-enable-autocomplete %{
     set buffer ycmd_completions %opt{ycmd_completions}
-    set -add buffer completers option=ycmd_completions
+    set buffer completers option=ycmd_completions
     hook -group ycmd_autocomplete window InsertIdle .* %{ try %{
         echo 'completing...'
         ycmd-complete
@@ -107,6 +107,7 @@ def ycmd-enable-autocomplete %{
 def ycmd-disable-autocomplete %{
     rmhooks window ycmd_autocomplete
     unset-option buffer ycmd_completions
+    unset-option buffer completers
 }
 
 # For debugging: send a request with path $1 and print the response to the debug window

--- a/ycmd.kak
+++ b/ycmd.kak
@@ -28,7 +28,7 @@ def ycmd-start %{ evaluate-commands %sh{
   "collect_identifiers_from_comments_and_strings": 0,
   "collect_identifiers_from_tags_files": 0,
   "extra_conf_globlist": [],
-  "global_ycm_extra_conf": "",
+  "global_ycm_extra_conf": "${kak_opt_ycmd_path}/../.ycm_extra_conf.py",
   "confirm_extra_conf": 0,
   "complete_in_comments": 0,
   "complete_in_strings": 1,

--- a/ycmd.kak
+++ b/ycmd.kak
@@ -14,7 +14,7 @@ def ycmd-start %{ evaluate-commands %sh{
     mkfifo ${dir}/fifo
 
     cp "${kak_opt_ycmd_settings_template_path}" ${dir}/options.json
-    sed -i -e "s/__HMAC_SECRET__/${key}/g" ${dir}/options.json
+    sed -i -e "s*__HMAC_SECRET__*${key}*g" ${dir}/options.json
 
     echo "set global ycmd_tmp_dir ${dir}
           set global ycmd_hmac_key ${key}
@@ -95,7 +95,6 @@ def ycmd-enable-autocomplete %{
     set buffer ycmd_completions %opt{ycmd_completions}
     set -add buffer completers option=ycmd_completions
     hook -group ycmd_autocomplete window InsertIdle .* %{ try %{
-        exec -draft <a-h><a-k>(\.|->|::).<ret>
         echo 'completing...'
         ycmd-complete
     } }


### PR DESCRIPTION
1. Fix type of `ycmd_completions`
2. Add `evaluate-commands` where necessary
3. Add default `.ycm_extra_conf.py` to options to stop ycmd from complaining.
4. Change `python` to `python3`
5. Added fixes from https://github.com/danr/kak-ycmd/commit/63476dc85741c99f05ba613f277aab7afdb1625a
6. Use `printf` instead of `echo` for hmac calculation. `echo` breaks the output from `jq` due to interpretation of escape sequences.
7. Change the way `ycmd_completions` is added to/removed from the completer list so that it works with v2018.09.04.